### PR TITLE
Add .gitattributes for proper language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gp linguist-language=porth

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.gp linguist-language=porth
+*.gp linguist-language=forth


### PR DESCRIPTION
Added .gitattributes for proper language detection, because .gp file extension detects as gnuplot, but should detect as forth